### PR TITLE
US2119, TA6579: Add set_pru_spreadspectrum and call it

### DIFF
--- a/arch/arm/include/asm/arch-am33xx/clock.h
+++ b/arch/arm/include/asm/arch-am33xx/clock.h
@@ -125,5 +125,6 @@ void enable_basic_clocks(void);
 void do_enable_clocks(u32 *const *, u32 *const *, u8);
 void do_disable_clocks(u32 *const *, u32 *const *, u8);
 
+void set_pru_spreadspectrum(u32 n, u32 m, u32 m2, u32 freq_div, u32 delta_m);
 void set_mpu_spreadspectrum(int permille);
 #endif

--- a/arch/arm/include/asm/arch-am33xx/cpu.h
+++ b/arch/arm/include/asm/arch-am33xx/cpu.h
@@ -89,7 +89,9 @@ struct cm_wkuppll {
 	unsigned int idlestdpllddr;	/* offset 0x34 */
 	unsigned int resv5[2];
 	unsigned int clkseldpllddr;	/* offset 0x40 */
-	unsigned int resv6[4];
+	unsigned int resv6[2];
+	unsigned int sscdeltamstepdplldisp;/* off 0x4C */
+	unsigned int sscmodfreqdivdplldisp;/* off 0x50 */
 	unsigned int clkseldplldisp;	/* offset 0x54 */
 	unsigned int resv7[1];
 	unsigned int idlestdpllcore;	/* offset 0x5c */
@@ -199,7 +201,8 @@ struct cm_dpll {
 	unsigned int clktimer6clk;	/* offset 0x1C */
 	unsigned int resv3[2];
 	unsigned int clktimer1clk;	/* offset 0x28 */
-	unsigned int resv4[2];
+	unsigned int resv4;
+	unsigned int clkpruicssocpclk;  /* offset 0x30 */
 	unsigned int clklcdcpixelclk;	/* offset 0x34 */
 };
 

--- a/arch/arm/mach-omap2/am33xx/board.c
+++ b/arch/arm/mach-omap2/am33xx/board.c
@@ -271,7 +271,7 @@ int board_early_init_f(void)
  */
 __weak void am33xx_spl_board_init(void)
 {
-	set_pru_spreadspectrum(0, 50, 6, 0x14, 0x2666);
+	set_pru_spreadspectrum(0, 0x32, 0x6, 0x14, 0x2666);
 }
 
 #if defined(CONFIG_SPL_AM33XX_ENABLE_RTC32K_OSC)

--- a/arch/arm/mach-omap2/am33xx/board.c
+++ b/arch/arm/mach-omap2/am33xx/board.c
@@ -271,6 +271,7 @@ int board_early_init_f(void)
  */
 __weak void am33xx_spl_board_init(void)
 {
+	set_pru_spreadspectrum(0, 50, 6, 0x14, 0x2666);
 }
 
 #if defined(CONFIG_SPL_AM33XX_ENABLE_RTC32K_OSC)

--- a/arch/arm/mach-omap2/am33xx/clock_am33xx.c
+++ b/arch/arm/mach-omap2/am33xx/clock_am33xx.c
@@ -246,7 +246,7 @@ void set_pru_spreadspectrum(u32 n, u32 m, u32 m2, u32 freq_div, u32 delta_m)
 	u32 ssc_deltamstep_dpll_disp;
 	u32 cm_clksel_pru_icss_ocp_clk;
 
-	printf("Enabling Spread Spectrum for PRU:\n"
+	printf("\n\nEnabling Spread Spectrum for PRU:\n"
 	       "         n: %4xh\n"
 	       "         m: %4xh\n"
 	       "        m2: %4xh\n"

--- a/arch/arm/mach-omap2/am33xx/clock_am33xx.c
+++ b/arch/arm/mach-omap2/am33xx/clock_am33xx.c
@@ -236,6 +236,87 @@ void enable_basic_clocks(void)
 	writel(0x1, &cmdpll->clktimer2clk);
 }
 
+void set_pru_spreadspectrum(u32 n, u32 m, u32 m2, u32 freq_div, u32 delta_m)
+{
+	u32 cm_clksel_dpll_disp;
+	u32 cm_div_m2_dpll_disp;
+	u32 cm_clkmode_dpll_disp;
+	u32 cm_idlest_dpll_disp;
+	u32 ssc_modfreqdiv_dpll_disp;
+	u32 ssc_deltamstep_dpll_disp;
+	u32 cm_clksel_pru_icss_ocp_clk;
+
+	printf("Enabling Spread Spectrum for PRU:\n"
+	       "         n: %4xh\n"
+	       "         m: %4xh\n"
+	       "        m2: %4xh\n"
+	       "  freq_div: %4xh\n"
+	       "   delta_m: %4xh\n"
+	       ,n, m, m2, freq_div, delta_m);
+
+	/* Put the DPLL in Bypass Mode. The CM_CLKMODE_DPLL_DISP.DPLL_MULT register bits are reset automatically */
+	cm_clkmode_dpll_disp = readl(dpll_disp_regs.cm_clkmode_dpll);
+	cm_clkmode_dpll_disp &= 0xfffffff8;
+	cm_clkmode_dpll_disp |= 0x00000004;
+	writel(cm_clkmode_dpll_disp, dpll_disp_regs.cm_clkmode_dpll);
+	while(!(readl(dpll_disp_regs.cm_idlest_dpll) & 0x100));
+
+	/* Set the division factors N, M and M2 */
+
+	cm_clksel_dpll_disp = readl(dpll_disp_regs.cm_clksel_dpll);
+	cm_clksel_dpll_disp &= ~0x7FFFF;
+	cm_clksel_dpll_disp |= (m << 0x8);
+	cm_clksel_dpll_disp |= n;
+	cm_div_m2_dpll_disp = 0xFFFFFFE0 | m2;
+	writel(cm_clksel_dpll_disp, dpll_disp_regs.cm_clksel_dpll);
+	writel(cm_div_m2_dpll_disp, dpll_disp_regs.cm_div_m2_dpll);
+
+	/* Program modulation frequency divider - exponent 0 | mantissa FREQ_DIV */
+	ssc_modfreqdiv_dpll_disp = readl(&cmwkup->sscmodfreqdivdplldisp);
+	ssc_modfreqdiv_dpll_disp &=  0xfffff880;
+	ssc_modfreqdiv_dpll_disp |= freq_div;
+	writel(ssc_modfreqdiv_dpll_disp, &cmwkup->sscmodfreqdivdplldisp);
+
+	/* Program the frequency spread - integer part 0 | fractional part DELTA_M */
+	ssc_deltamstep_dpll_disp = readl(&cmwkup->sscdeltamstepdplldisp);
+	ssc_deltamstep_dpll_disp &=  0xfff00000;
+	ssc_deltamstep_dpll_disp |= delta_m;
+	writel(ssc_deltamstep_dpll_disp, &cmwkup->sscdeltamstepdplldisp);
+
+	/* Set the SCC Mode and Enable the DPLL in Lock Mode */
+	cm_clkmode_dpll_disp &= 0xffff2ff8;
+	cm_clkmode_dpll_disp |= (1 << 0xC);
+	cm_clkmode_dpll_disp |= 0x07;
+	writel(cm_clkmode_dpll_disp, dpll_disp_regs.cm_clkmode_dpll);
+	while(!((cm_idlest_dpll_disp = readl(dpll_disp_regs.cm_idlest_dpll)) & 0x1));
+
+	/* Switch the PRU-ICSS OCP clock to DISP DPLL */
+	writel(0x1, &cmdpll->clkpruicssocpclk);
+
+	/* Read them back */
+	cm_clkmode_dpll_disp = readl(dpll_disp_regs.cm_clkmode_dpll);
+	cm_clksel_dpll_disp = readl(dpll_disp_regs.cm_clksel_dpll);
+	cm_div_m2_dpll_disp = readl(dpll_disp_regs.cm_div_m2_dpll);
+	ssc_modfreqdiv_dpll_disp = readl(&cmwkup->sscmodfreqdivdplldisp);
+	ssc_deltamstep_dpll_disp = readl(&cmwkup->sscdeltamstepdplldisp);
+	cm_clksel_pru_icss_ocp_clk = readl(&cmdpll->clkpruicssocpclk);
+
+
+
+	printf("Final values:\n"
+	       "         cm_idlest_dpll_disp: %08xh\n"
+	       "        cm_clkmode_dpll_disp: %08xh\n"
+	       "         cm_clksel_dpll_disp: %08xh\n"
+	       "         cm_div_m2_dpll_disp: %08xh\n"
+	       "    ssc_modfreqdiv_dpll_disp: %08xh\n"
+	       "    ssc_deltamstep_dpll_disp: %08xh\n"
+	       "  cm_clksel_pru_icss_ocp_clk: %08xh\n"
+	       ,cm_idlest_dpll_disp, cm_clkmode_dpll_disp, cm_clksel_dpll_disp
+	       ,cm_div_m2_dpll_disp, ssc_modfreqdiv_dpll_disp
+	       ,ssc_deltamstep_dpll_disp, cm_clksel_pru_icss_ocp_clk);
+
+}
+
 /*
  * Enable Spread Spectrum for the MPU by calculating the required
  * values and setting the registers accordingly.

--- a/board/ti/am335x/board.c
+++ b/board/ti/am335x/board.c
@@ -9,6 +9,7 @@
  */
 
 #include <common.h>
+#include <command.h>
 #include <dm.h>
 #include <errno.h>
 #include <spl.h>
@@ -978,3 +979,26 @@ U_BOOT_DEVICE(am335x_mmc1) = {
 	.platdata = &am335x_mmc1_platdata,
 };
 #endif
+
+static int do_prussc(cmd_tbl_t *cmdtp, int flag, int argc, char * const argv[])
+{
+	if (argc == 6) {
+		u32 n, m, m2, freq_div, delta_m;
+
+		n = simple_strtoul(argv[1], NULL, 16);
+		m = simple_strtoul(argv[2], NULL, 16);
+		m2 = simple_strtoul(argv[3], NULL, 16);
+		freq_div = simple_strtoul(argv[4], NULL, 16);
+		delta_m = simple_strtoul(argv[5], NULL, 16);
+
+		set_pru_spreadspectrum(n, m, m2, freq_div, delta_m);
+	} else {
+		return CMD_RET_USAGE;
+	}
+	return 0;
+}
+
+U_BOOT_CMD(prussc, 6, 1, do_prussc, "set PRU Spread Spectrum Clocking",
+	   "<n> <m> <m2> <freq_div> <delta_m>\n"
+	   "    - Set PRU Spread Spectrum Clocking parameters. All values\n"
+       "      are in hex.\n");


### PR DESCRIPTION
I mainly don't want this sitting somewhere hidden, to be lost if I decided to join the circus over the weekend. :circus_tent: :clown_face: 

This **does** set the PRU to use a spread spectrum clock. Kris has pretty pictures. This isn't one of them:
![image](https://user-images.githubusercontent.com/2463873/35174359-b53330c6-fd34-11e7-9c1d-a4b7f96bb623.png)
