### PR TITLE
US2144, TA6739: Check for SD card, if not, use eMMC

### DIFF
--- a/include/configs/am335x_evm.h
+++ b/include/configs/am335x_evm.h
@@ -95,7 +95,7 @@
 	"bootpart=0:2\0" \
 	"bootdir=/boot\0" \
 	"bootfile=zImage\0" \
-	"fdtfile=undefined\0" \
+	"fdtfile=xl-bone.dtb\0" \
 	"console=ttyO0,115200n8\0" \
 	"partitions=" \
 		"uuid_disk=${uuid_gpt_disk};" \
@@ -126,24 +126,6 @@
 		"run ramargs; " \
 		"bootz ${loadaddr} ${rdaddr} ${fdtaddr}\0" \
 	"findfdt="\
-		"if test $board_name = A335BONE; then " \
-			"setenv fdtfile am335x-bone.dtb; fi; " \
-		"if test $board_name = A335BNLT; then " \
-			"setenv fdtfile am335x-boneblack.dtb; fi; " \
-		"if test $board_name = BBBW; then " \
-			"setenv fdtfile am335x-boneblack-wireless.dtb; fi; " \
-		"if test $board_name = BBG1; then " \
-			"setenv fdtfile am335x-bonegreen.dtb; fi; " \
-		"if test $board_name = BBGW; then " \
-			"setenv fdtfile am335x-bonegreen-wireless.dtb; fi; " \
-		"if test $board_name = BBBL; then " \
-			"setenv fdtfile am335x-boneblue.dtb; fi; " \
-		"if test $board_name = A33515BB; then " \
-			"setenv fdtfile am335x-evm.dtb; fi; " \
-		"if test $board_name = A335X_SK; then " \
-			"setenv fdtfile am335x-evmsk.dtb; fi; " \
-		"if test $board_name = A335_ICE; then " \
-			"setenv fdtfile am335x-icev2.dtb; fi; " \
 		"if test $fdtfile = undefined; then " \
 			"echo WARNING: Could not determine device tree to use; fi; \0" \
 	"init_console=" \

--- a/include/environment/ti/mmc.h
+++ b/include/environment/ti/mmc.h
@@ -26,7 +26,14 @@
 	"loadbootenv=fatload mmc ${mmcdev} ${loadaddr} ${bootenvfile}\0" \
 	"loadimage=load ${devtype} ${bootpart} ${loadaddr} ${bootdir}/${bootfile}\0" \
 	"loadfdt=load ${devtype} ${bootpart} ${fdtaddr} ${bootdir}/${fdtfile}\0" \
-	"envboot=mmc dev ${mmcdev}; " \
+	"envboot=mmc dev 0; " \
+		"if mmc rescan ; " \
+			"then echo micro SD card found;" \
+			"setenv mmcdev 0;" \
+		"else echo No micro SD card found, setting mmcdev to 1;" \
+			"setenv mmcdev 1;" \
+		"fi;" \
+		"mmc dev ${mmcdev}; " \
 		"if mmc rescan; then " \
 			"echo SD/MMC found on device ${mmcdev};" \
 			"if run loadbootscript; then " \


### PR DESCRIPTION
This introduces some slight tweaks to our process to allow the BBB to boot correctly.

I cleaned up the "fdt" stuff so we just directly use our custom device tree.

Then then `envboot` change matches more closely with what u-boot was doing on the debian image. (which also allows the flasher card to work without pushing the button).