### PR TITLE
US2177, TA6923: Remove default spread spectrum changes

### DIFF
--- a/arch/arm/mach-omap2/am33xx/board.c
+++ b/arch/arm/mach-omap2/am33xx/board.c
@@ -272,7 +272,6 @@ int board_early_init_f(void)
  */
 __weak void am33xx_spl_board_init(void)
 {
-	set_pru_spreadspectrum(0, 0x32, 0x6, 0x14, 0x2666);
 	init_pru_icss();
 	enable_vorne_810_display_pin_mux();
 }


### PR DESCRIPTION
Merge along-side https://github.com/Vorne/meta-vorne/pull/75 otherwise you'll break `console-image` builds

We will instead do this in the `uEnv.txt` so that HD Scoreboard will not inherit these defaults.